### PR TITLE
Removing query check to add support for PowerBI

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,6 @@ import * as swaggerUi from 'swagger-ui-express';
 import { InjectKey, ServerType } from './constants';
 import { ODataController } from './controller';
 import { ContainerBase } from './edm';
-import { HttpRequestError } from './error';
 import { createMetadataJSON } from './metadata';
 import { ensureODataHeaders, withODataBatchRequestHandler, withODataErrorHandler, withODataHeader, withODataRequestHandler, withODataVersionVerify, withSwaggerDocument } from './middlewares';
 import * as odata from './odata';
@@ -223,9 +222,6 @@ export class ODataServerBase {
     router.use(withODataHeader);
 
     router.get('/', ensureODataHeaders, (req, _, next) => {
-      if (typeof req.query == 'object' && Object.keys(req.query).length > 0) {
-        return next(new HttpRequestError(500, 'Unsupported query'));
-      }
       next();
     }, server.document().requestHandler());
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -221,9 +221,7 @@ export class ODataServerBase {
 
     router.use(withODataHeader);
 
-    router.get('/', ensureODataHeaders, (req, _, next) => {
-      next();
-    }, server.document().requestHandler());
+    router.get('/', ensureODataHeaders, server.document().requestHandler());
 
     router.get('/\\$metadata', server.$metadata().requestHandler());
 

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -706,15 +706,6 @@ describe('OData HTTP', () => {
     });
   });
 
-  describe('Use query in service document', () => {
-    it("shuld return 'Unsupported query' error", () => request.get(`http://localhost:3002/?$expand=Any`, (err, req, res) => {
-      expect(JSON.parse(res).error.message).toEqual('Unsupported query');
-    })
-      .catch((ex) => {
-        expect(JSON.parse(ex.error).error.message).toEqual('Unsupported query');
-      }));
-  });
-
   describe('Not implemented error', () => {
     it('should return not implemented error', () => request.get(`http://localhost:3002/EntitySet`, () => {
       try {


### PR DESCRIPTION
When working with PowerBI, it natively supports OData, as well as API key based authentication.  However, in doing so it requires the key be passed as a query Parameter, [specified by `ApiKeyName` property as documented here](https://docs.microsoft.com/en-us/powerquery-m/odata-feed).  Currently, `@odata/server` complains about any query parameter on the root request.  Removing this check allows powerBI to function as intended.  If there's another reason to have this check in there, maybe a more specific check based on an option can be added, so we can allow one specific query parameter?